### PR TITLE
feat(acl): add ACL middleware for role-based access control

### DIFF
--- a/src/middlewares/acl.middleware.ts
+++ b/src/middlewares/acl.middleware.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Response } from "express";
+import { IReqUser } from "./auth.middleware";
+
+export default (roles: string[]) => {
+  return (req: IReqUser, res: Response, next: NextFunction) => {
+    const role = req.user?.role;
+
+    if (!role || !roles.includes(role)) {
+      return res.status(403).json({
+        message: "forbidden",
+        data: null,
+      });
+    }
+    next();
+  };
+};

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import { encrypt, verifyPassword } from "../utils/password";
+import { ROLES } from "../utils/constant";
 
 export interface IUser {
   fullName: string;
@@ -39,8 +40,8 @@ const UserSchema = new Schema<IUser>(
     },
     role: {
       type: String,
-      enum: ["user", "admin"],
-      default: "user",
+      enum: [ROLES.ADMIN, ROLES.MEMBER],
+      default: ROLES.MEMBER,
       required: true,
     },
     profilePicture: {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,13 +1,21 @@
 import express from "express";
 import authController from "../controllers/auth.controller";
 import authMiddleware from "../middlewares/auth.middleware";
+import aclMiddleware from "../middlewares/acl.middleware";
+import { ROLES } from "../utils/constant";
 
 const router = express.Router();
-
 
 router.post("/auth/register", authController.register);
 router.post("/auth/login", authController.login);
 router.get("/auth/me", authMiddleware, authController.me);
 router.post("/auth/activation", authController.activation);
+
+router.get("/test-acl", authMiddleware, aclMiddleware([ROLES.ADMIN, ROLES.MEMBER]), (req, res) => {
+  res.json({
+    message: "OK",
+    data: "Success",
+  });
+});
 
 export default router;

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,0 +1,4 @@
+export enum ROLES {
+  ADMIN = "admin",
+  MEMBER = "member",
+}


### PR DESCRIPTION
## Summary by Sourcery

Add role-based access control by defining a ROLES constant, introducing ACL middleware, updating the user model to use these roles, and applying the middleware to secure a test endpoint

New Features:
- Introduce ACL middleware to enforce role-based access control
- Add ROLES enum for 'admin' and 'member' roles
- Protect `/test-acl` endpoint with authentication and ACL middleware

Enhancements:
- Update User schema to use ROLES enum for role field and default to `MEMBER`