### PR TITLE
feat(category): add CRUD operations and validation for categories

### DIFF
--- a/src/controllers/category.controller.ts
+++ b/src/controllers/category.controller.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
 import CategoryModel from "../models/category.model";
-import { categorySchema, TCategory } from "../validators/category.schema";
+import { categorySchema } from "../validators/category.schema";
 import response from "../utils/response";
 import { IPaginationQuery, IReqUser } from "../utils/interfaces";
 

--- a/src/controllers/category.controller.ts
+++ b/src/controllers/category.controller.ts
@@ -1,0 +1,74 @@
+import { Response } from "express";
+import CategoryModel from "../models/category.model";
+import { categorySchema, TCategory } from "../validators/category.schema";
+import response from "../utils/response";
+import { IPaginationQuery, IReqUser } from "../utils/interfaces";
+
+export default {
+  async create(req: IReqUser, res: Response) {
+    try {
+      await categorySchema.validate(req.body);
+      const result = await CategoryModel.create(req.body);
+      response.success(res, result, "success create category");
+    } catch (error) {
+      response.error(res, error, "failed create category");
+    }
+  },
+  async findAll(req: IReqUser, res: Response) {
+    const { page = 1, limit = 10, search } = req.query as unknown as IPaginationQuery;
+
+    try {
+      const query = {};
+      if (search) {
+        Object.assign(query, {
+          $or: [
+            {
+              name: { $regex: search, $options: "i" },
+            },
+            {
+              description: { $regex: search, $options: "i" },
+            },
+          ],
+        });
+      }
+      const count = await CategoryModel.countDocuments(query);
+      const result = await CategoryModel.find(query)
+        .limit(limit)
+        .skip((page - 1) * limit)
+        .sort({ createdAt: -1 })
+        .exec();
+      response.pagination(res, "success find all category", { total: count, totalPages: Math.ceil(count / limit), currentPages: page }, result);
+    } catch (error) {
+      response.error(res, error, "failed find all category");
+    }
+  },
+  async findOne(req: IReqUser, res: Response) {
+    try {
+      const { id } = req.params;
+      const result = await CategoryModel.findById(id);
+      response.success(res, result, "success find one category");
+    } catch (error) {
+      response.error(res, error, "failed find one category");
+    }
+  },
+  async update(req: IReqUser, res: Response) {
+    try {
+      const { id } = req.params;
+      const result = await CategoryModel.findByIdAndUpdate(id, req.body, {
+        new: true,
+      });
+      response.success(res, result, "success update category");
+    } catch (error) {
+      response.error(res, error, "failed update category");
+    }
+  },
+  async remove(req: IReqUser, res: Response) {
+    try {
+      const { id } = req.params;
+      const result = await CategoryModel.findByIdAndDelete(id);
+      response.success(res, result, "success remove category");
+    } catch (error) {
+      response.error(res, error, "failed remove category");
+    }
+  },
+};

--- a/src/controllers/category.controller.ts
+++ b/src/controllers/category.controller.ts
@@ -37,7 +37,7 @@ export default {
         .skip((page - 1) * limit)
         .sort({ createdAt: -1 })
         .exec();
-      response.pagination(res, "success find all category", { total: count, totalPages: Math.ceil(count / limit), currentPages: page }, result);
+      response.pagination(res, "success find all category", { total: count, totalPages: Math.ceil(count / limit), currentPage: page }, result);
     } catch (error) {
       response.error(res, error, "failed find all category");
     }

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 
 import { TCategory } from "../validators/category.schema";
 
-const Schema = mongoose.Schema;
+const { Schema } = mongoose;
 
 const categorySchema = new Schema<TCategory>({
   name: {

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,0 +1,24 @@
+import mongoose from "mongoose";
+
+import { TCategory } from "../validators/category.schema";
+
+const Schema = mongoose.Schema;
+
+const categorySchema = new Schema<TCategory>({
+  name: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    required: true,
+  },
+  icon: {
+    type: String,
+    required: true,
+  },
+});
+
+const CategoryModel = mongoose.model("Category", categorySchema);
+
+export default CategoryModel;

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -5,6 +5,7 @@ import aclMiddleware from "../middlewares/acl.middleware";
 import mediaMiddleware from "../middlewares/media.middleware";
 import { ROLES } from "../utils/constant";
 import mediaController from "../controllers/media.controller";
+import categoryController from "../controllers/category.controller";
 
 const router = express.Router();
 
@@ -19,6 +20,12 @@ router.get("/test-acl", authMiddleware, aclMiddleware([ROLES.ADMIN, ROLES.MEMBER
     data: "Success",
   });
 });
+
+router.post("/category", [authMiddleware, aclMiddleware([ROLES.ADMIN])], categoryController.create);
+router.get("/category", categoryController.findAll);
+router.get("/category/:id", categoryController.findOne);
+router.put("/category/:id", [authMiddleware, aclMiddleware([ROLES.ADMIN])], categoryController.update);
+router.delete("/category/:id", [authMiddleware, aclMiddleware([ROLES.ADMIN])], categoryController.remove);
 
 router.post("/media/upload-single", [authMiddleware, aclMiddleware([ROLES.ADMIN, ROLES.MEMBER]), mediaMiddleware.single("file")], mediaController.single);
 router.post("/media/upload-multiple", [authMiddleware, aclMiddleware([ROLES.ADMIN, ROLES.MEMBER]), mediaMiddleware.multiple("files", 5)], mediaController.multiple);

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -9,3 +9,9 @@ export interface IReqUser extends Request {
 export interface IUserToken extends Omit<IUser, "password" | "email" | "username" | "fullName" | "profilePicture" | "profilePictureId" | "isActive" | "activationCode"> {
   id?: Types.ObjectId;
 }
+
+export interface IPaginationQuery {
+  page: number;
+  limit: number;
+  search?: string;
+}

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -3,7 +3,7 @@ import * as Yup from "yup";
 
 type Pagination = {
   totalPages: number;
-  currentPages: number;
+  currentPage: number;
   total: number;
 };
 

--- a/src/validators/auth.schema.ts
+++ b/src/validators/auth.schema.ts
@@ -1,7 +1,6 @@
 import * as Yup from "yup";
 import { passwordRules } from "../utils/passwordRules";
 
-// Schema untuk Register
 export const registerSchema = Yup.object({
   fullName: Yup.string().required("Full name is required"),
   username: Yup.string().required("Username is required"),
@@ -12,12 +11,10 @@ export const registerSchema = Yup.object({
     .oneOf([Yup.ref("password")], "Passwords must match"),
 });
 
-// Schema untuk Login
 export const loginSchema = Yup.object({
   identifier: Yup.string().required("Username or Email is required"),
   password: Yup.string().required("Password is required"),
 });
 
-// Types otomatis dari Yup
 export type TRegister = Yup.InferType<typeof registerSchema>;
 export type TLogin = Yup.InferType<typeof loginSchema>;

--- a/src/validators/category.schema.ts
+++ b/src/validators/category.schema.ts
@@ -1,0 +1,9 @@
+import * as Yup from "yup";
+
+export const categorySchema = Yup.object({
+  name: Yup.string().required("Category name is required"),
+  description: Yup.string().required("Category description is required"),
+  icon: Yup.string().required("Category icon is required"),
+});
+
+export type TCategory = Yup.InferType<typeof categorySchema>;


### PR DESCRIPTION
## Summary by Sourcery

Add full CRUD support for categories, including model definition, request validation, pagination, search, and route integration with ACL enforcement

New Features:
- Add category REST endpoints with create, read, update, and delete operations secured by authentication and role-based access control
- Implement category controller with Yup-based input validation, paginated listing, and search functionality
- Define Category mongoose model and Yup validation schema for category data

Enhancements:
- Introduce IPaginationQuery interface for pagination parameters
- Clean up redundant comments in the authentication schema