### PR TITLE
feat(region): add region api

### DIFF
--- a/src/controllers/region.controller.ts
+++ b/src/controllers/region.controller.ts
@@ -1,0 +1,59 @@
+import { Request, Response } from "express";
+import response from "../utils/response";
+import RegionModel from "../models/region.model";
+
+export default {
+  async findByCity(req: Request, res: Response) {
+    try {
+      const { name } = req.query;
+      const result = await RegionModel.findByCity(`${name}`);
+      response.success(res, result, "success get region by city name");
+    } catch (error) {
+      response.error(res, error, "failed to get region by city name");
+    }
+  },
+  async getAllProvinces(req: Request, res: Response) {
+    try {
+      const result = await RegionModel.getAllProvinces();
+      response.success(res, result, "success get all provinces");
+    } catch (error) {
+      response.error(res, error, "failed to get all provinces");
+    }
+  },
+  async getProvince(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const result = await RegionModel.getProvince(Number(id));
+      response.success(res, result, "success get a province");
+    } catch (error) {
+      response.error(res, error, "failed to get province");
+    }
+  },
+  async getRegency(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const result = await RegionModel.getRegency(Number(id));
+      response.success(res, result, "success get regencies");
+    } catch (error) {
+      response.error(res, error, "failed to get regency");
+    }
+  },
+  async getDistrict(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const result = await RegionModel.getDistrict(Number(id));
+      response.success(res, result, "success get districts");
+    } catch (error) {
+      response.error(res, error, "failed to get district");
+    }
+  },
+  async getVillage(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const result = await RegionModel.getVillage(Number(id));
+      response.success(res, result, "success get villages");
+    } catch (error) {
+      response.error(res, error, "failed to get village");
+    }
+  },
+};

--- a/src/models/region.model.ts
+++ b/src/models/region.model.ts
@@ -1,0 +1,240 @@
+import mongoose from "mongoose";
+
+const villageSchema = new mongoose.Schema({
+  id: { type: Number, index: true },
+  name: String,
+}).index({ name: "text" });
+
+const districtSchema = new mongoose.Schema({
+  id: { type: Number, index: true },
+  name: String,
+  villages: [villageSchema],
+}).index({ name: "text" });
+
+const regencySchema = new mongoose.Schema({
+  id: { type: Number, index: true },
+  name: String,
+  districts: [districtSchema],
+}).index({ name: "text" });
+
+const provinceSchema = new mongoose.Schema(
+  {
+    id: { type: Number, index: true },
+    name: String,
+    regencies: [regencySchema],
+  },
+  {
+    statics: {
+      findByCity(name: string) {
+        return this.aggregate([
+          {
+            $unwind: "$regencies",
+          },
+          {
+            $match: {
+              $or: [
+                {
+                  "regencies.name": { $regex: name, $options: "i" },
+                },
+              ],
+            },
+          },
+          {
+            $project: {
+              id: "$regencies.id",
+              name: "$regencies.name",
+            },
+          },
+          {
+            $replaceRoot: {
+              newRoot: {
+                name: "$name",
+                id: "$id",
+                province: "$province",
+                regency: "$regency",
+                district: "$district",
+              },
+            },
+          },
+        ]);
+      },
+      getAllProvinces() {
+        return this.find({}).select("name id -_id");
+      },
+      getProvince(id: number) {
+        return this.aggregate([
+          {
+            $match: { id },
+          },
+          {
+            $project: {
+              name: "$name",
+              id: "$id",
+              regencies: {
+                $map: {
+                  input: "$regencies",
+                  as: "regencies",
+                  in: {
+                    id: "$$regencies.id",
+                    name: "$$regencies.name",
+                  },
+                },
+              },
+            },
+          },
+          {
+            $replaceRoot: {
+              newRoot: {
+                name: "$name",
+                id: "$id",
+                regencies: "$regencies",
+              },
+            },
+          },
+        ]);
+      }, // province
+      getRegency(id: number) {
+        return this.aggregate([
+          {
+            $unwind: "$regencies",
+          },
+          {
+            $match: {
+              "regencies.id": id,
+            },
+          },
+          {
+            $project: {
+              name: "$regencies.name",
+              id: "$regencies.id",
+              province: {
+                id: "$id",
+                name: "$name",
+              },
+              districts: {
+                $map: {
+                  input: "$regencies.districts",
+                  as: "districts",
+                  in: {
+                    id: "$$districts.id",
+                    name: "$$districts.name",
+                  },
+                },
+              },
+            },
+          },
+          {
+            $replaceRoot: {
+              newRoot: {
+                name: "$name",
+                id: "$id",
+                province: "$province",
+                districts: "$districts",
+              },
+            },
+          },
+        ]);
+      }, // kota / kabupaten
+      getDistrict(id: number) {
+        return this.aggregate([
+          {
+            $unwind: "$regencies",
+          },
+          {
+            $unwind: "$regencies.districts",
+          },
+          {
+            $match: {
+              "regencies.districts.id": id,
+            },
+          },
+          {
+            $project: {
+              name: "$regencies.districts.name",
+              id: "$regencies.districts.id",
+              province: {
+                id: "$id",
+                name: "$name",
+              },
+              regency: {
+                id: "$regencies.id",
+                name: "$regencies.name",
+              },
+              villages: {
+                $map: {
+                  input: "$regencies.districts.villages",
+                  as: "villages",
+                  in: {
+                    id: "$$villages.id",
+                    name: "$$villages.name",
+                  },
+                },
+              },
+            },
+          },
+          {
+            $replaceRoot: {
+              newRoot: {
+                name: "$name",
+                id: "$id",
+                province: "$province",
+                regency: "$regency",
+                villages: "$villages",
+              },
+            },
+          },
+        ]);
+      }, // kecamtan
+      getVillage(id: number) {
+        return this.aggregate([
+          {
+            $unwind: "$regencies",
+          },
+          {
+            $unwind: "$regencies.districts",
+          },
+          {
+            $unwind: "$regencies.districts.villages",
+          },
+          {
+            $match: {
+              "regencies.districts.villages.id": id,
+            },
+          },
+          {
+            $project: {
+              name: "$regencies.districts.villages.name",
+              id: "$regencies.districts.villages.id",
+              district: {
+                id: "$regencies.districts.id",
+                name: "$regencies.districts.name",
+              },
+              regency: {
+                id: "$regencies.id",
+                name: "$regencies.name",
+              },
+              province: {
+                id: "$id",
+                name: "$name",
+              },
+            },
+          },
+          {
+            $replaceRoot: {
+              newRoot: {
+                name: "$name",
+                id: "$id",
+                province: "$province",
+                regency: "$regency",
+                district: "$district",
+              },
+            },
+          },
+        ]);
+      }, // kelurahan
+    },
+  }
+).index({ name: "text" });
+
+const RegionModel = mongoose.model("Region", provinceSchema);
+export default RegionModel;

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -6,6 +6,7 @@ import mediaMiddleware from "../middlewares/media.middleware";
 import { ROLES } from "../utils/constant";
 import mediaController from "../controllers/media.controller";
 import categoryController from "../controllers/category.controller";
+import regionController from "../controllers/region.controller";
 
 const router = express.Router();
 
@@ -26,6 +27,13 @@ router.get("/category", categoryController.findAll);
 router.get("/category/:id", categoryController.findOne);
 router.put("/category/:id", [authMiddleware, aclMiddleware([ROLES.ADMIN])], categoryController.update);
 router.delete("/category/:id", [authMiddleware, aclMiddleware([ROLES.ADMIN])], categoryController.remove);
+
+router.get("/regions", regionController.getAllProvinces);
+router.get("/regions/:id/province", regionController.getProvince);
+router.get("/regions/:id/regency", regionController.getRegency);
+router.get("/regions/:id/district", regionController.getDistrict);
+router.get("/regions/:id/village", regionController.getVillage);
+router.get("/regions-search", regionController.findByCity);
 
 router.post("/media/upload-single", [authMiddleware, aclMiddleware([ROLES.ADMIN, ROLES.MEMBER]), mediaMiddleware.single("file")], mediaController.single);
 router.post("/media/upload-multiple", [authMiddleware, aclMiddleware([ROLES.ADMIN, ROLES.MEMBER]), mediaMiddleware.multiple("files", 5)], mediaController.multiple);


### PR DESCRIPTION
## Summary by Sourcery

Add a new region API for hierarchical region data lookup and search by city name

New Features:
- Introduce a Region Mongoose model with nested province, regency, district, and village schemas and static query methods
- Implement region.controller with endpoints to fetch all provinces, specific province/regency/district/village by ID, and search regions by city name
- Register new region routes in the API router for hierarchical lookups and region search